### PR TITLE
Fix ingestion of Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Crie um arquivo `.env` com sua `OPENAI_API_KEY`.
 
 ## Preparando os documentos
 
-Coloque seus arquivos `.txt` em `docs/` e execute:
+Coloque seus arquivos `.txt` ou `.md` em `docs/` e execute:
 
 ```bash
 python ingest.py

--- a/ingest.py
+++ b/ingest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # ingest.py
 # ------------
-# 1. Load all .txt files from ./docs
+# 1. Load all text files from ./docs
 # 2. Chunk them with overlap
 # 3. Persist chunks.json (id, text, metadata)
 # 4. Embed in batches via OpenAI
@@ -32,11 +32,12 @@ def main():
 
     # 2. Read & chunk all docs
     docs = []
-    for fname in os.listdir("docs"):
-        if not fname.endswith(".txt"):
+    for fname in sorted(os.listdir("docs")):
+        if not (fname.endswith(".txt") or fname.endswith(".md")):
             continue
         path = os.path.join("docs", fname)
-        text = open(path, encoding="utf-8").read()
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
         chunks = splitter.split_text(text)
         for i, chunk in enumerate(chunks):
             docs.append({
@@ -49,6 +50,10 @@ def main():
     with open("chunks.json", "w", encoding="utf-8") as f:
         json.dump(docs, f, ensure_ascii=False, indent=2)
     print(f"✅ Wrote chunks.json with {len(docs)} entries")
+
+    if not docs:
+        print("⚠️ Nenhum documento encontrado em 'docs/'.")
+        return
 
     # 4. Embed texts with caching to save OpenAI costs
     embeddings = [get_embedding(d["text"]).tolist() for d in docs]


### PR DESCRIPTION
## Summary
- handle `.md` files in `ingest.py`
- warn when docs folder has no valid files
- update README to mention support for `.md` files

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*
- `python ingest.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684864a7e7cc8326b273a648357e760b