### PR TITLE
Improve cache handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ Use `SESSION_ID=myid python app.py` para continuar uma sessão existente. O hist
 
 O projeto possui cache de embeddings e respostas em `embed_cache.json` e `completion_cache.json`. Defina `LOCAL_EMBED_MODEL` para usar um modelo do `sentence-transformers` e evitar chamadas à API para embeddings.
 
+Se esses arquivos ficarem corrompidos (por exemplo, erros de JSON), apague-os para que sejam recriados automaticamente.
+

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import logging
 from typing import List, Dict
 
 import numpy as np
@@ -16,14 +17,22 @@ RESP_CACHE_PATH = os.getenv("RESP_CACHE", "completion_cache.json")
 
 # Load caches
 if os.path.exists(EMBED_CACHE_PATH):
-    with open(EMBED_CACHE_PATH, "r", encoding="utf-8") as f:
-        _EMBED_CACHE: Dict[str, List[float]] = json.load(f)
+    try:
+        with open(EMBED_CACHE_PATH, "r", encoding="utf-8") as f:
+            _EMBED_CACHE: Dict[str, List[float]] = json.load(f)
+    except json.JSONDecodeError:
+        logging.warning("Failed to decode %s, starting with empty embed cache", EMBED_CACHE_PATH)
+        _EMBED_CACHE = {}
 else:
     _EMBED_CACHE = {}
 
 if os.path.exists(RESP_CACHE_PATH):
-    with open(RESP_CACHE_PATH, "r", encoding="utf-8") as f:
-        _RESP_CACHE: Dict[str, str] = json.load(f)
+    try:
+        with open(RESP_CACHE_PATH, "r", encoding="utf-8") as f:
+            _RESP_CACHE: Dict[str, str] = json.load(f)
+    except json.JSONDecodeError:
+        logging.warning("Failed to decode %s, starting with empty completion cache", RESP_CACHE_PATH)
+        _RESP_CACHE = {}
 else:
     _RESP_CACHE = {}
 


### PR DESCRIPTION
## Summary
- handle corrupted JSON caches in utils
- warn and reset caches if needed
- mention deleting cache files in README

## Testing
- `python -m py_compile utils.py app.py ingest.py query.py memory.py`


------
https://chatgpt.com/codex/tasks/task_e_684889e4c5588326abeae40235a9d32e