### PR TITLE
Adjust embedding cache writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ python ingest.py
 ```
 
 Os chunks serão armazenados em `chunks.json` e o índice em `faiss.index`.
+Os caches de embeddings agora são salvos apenas ao final da ingestão para reduzir escritas em disco.
 
 ## Executando
 
@@ -41,6 +42,7 @@ Use `SESSION_ID=myid python app.py` para continuar uma sessão existente. O hist
 ## Controles de custo
 
 O projeto possui cache de embeddings e respostas em `embed_cache.json` e `completion_cache.json`. Defina `LOCAL_EMBED_MODEL` para usar um modelo do `sentence-transformers` e evitar chamadas à API para embeddings.
+Durante a ingestão, os embeddings são persistidos em lote somente ao final do processo.
 
 Se esses arquivos ficarem corrompidos (por exemplo, erros de JSON), apague-os para que sejam recriados automaticamente.
 

--- a/ingest.py
+++ b/ingest.py
@@ -17,7 +17,7 @@ import faiss
 from dotenv import load_dotenv
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
-from utils import get_embedding
+from utils import get_embedding, flush_cache
 
 def main():
     # Load your OpenAI API key from .env
@@ -75,6 +75,9 @@ def main():
             f, ensure_ascii=False, indent=2
         )
     print("✅ Wrote metadatas.json")
+
+    # Persist caches only once after all embeddings are processed
+    flush_cache()
 
 if __name__ == "__main__":
     main()

--- a/utils.py
+++ b/utils.py
@@ -49,6 +49,11 @@ def save_caches() -> None:
         json.dump(_RESP_CACHE, f)
 
 
+def flush_cache() -> None:
+    """Persist caches to disk."""
+    save_caches()
+
+
 def get_embedding(text: str) -> np.ndarray:
     if text in _EMBED_CACHE:
         return np.array(_EMBED_CACHE[text], dtype="float32")
@@ -58,7 +63,6 @@ def get_embedding(text: str) -> np.ndarray:
         resp = client.embeddings.create(model="text-embedding-ada-002", input=[text])
         emb = resp.data[0].embedding
     _EMBED_CACHE[text] = emb
-    save_caches()
     return np.array(emb, dtype="float32")
 
 


### PR DESCRIPTION
## Summary
- keep caches in memory during ingestion
- add `flush_cache()` helper
- persist caches once when ingestion finishes
- document that embeddings are saved at the end

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849c29fec0c83269d20f2eded577294