### PR TITLE
Melhora identificação de documentos nas respostas

### DIFF
--- a/query.py
+++ b/query.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 
 from openai import OpenAI
 from memory import EphemeralMemory
-from utils import get_embedding, cached_completion
+from utils import get_embedding, cached_completion, humanize_doc_id
 
 # Carrega configuração e modelos
 load_dotenv()  # garante OPENAI_API_KEY
@@ -39,7 +39,8 @@ def answer(query: str) -> str:
     prompt_chunks = []
     for cid, score in doc_hits:
         text = chunk_map[cid]
-        prompt_chunks.append(f"=== (score: {score:.3f}) [{cid}]\n{text}\n")
+        display_name = humanize_doc_id(cid)
+        prompt_chunks.append(f"=== (score: {score:.3f}) [{display_name}]\n{text}\n")
 
     doc_context = "\n".join(prompt_chunks)
     mem_context = "\n".join(mem_hits)

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ import json
 import os
 import logging
 from typing import List, Dict
+import re
 
 import numpy as np
 from openai import OpenAI
@@ -76,8 +77,8 @@ def cached_completion(prompt: str) -> str:
         "úteis com base nas informações disponíveis. Use o contexto fornecido para "
         "responder às perguntas do usuário. Se não souber a resposta, diga que não "
         "sabe e sugira consultar os documentos relevantes que você possui. Sempre "
-        "responda em Português-BR, mantendo um tom profissional e claro. 
-        Cada resposta que você fornecer, deve também mostrar em qual documento essa informação está presente\n\n"
+        "responda em Português-BR, mantendo um tom profissional e claro. "
+        "Cada resposta que você fornecer deve citar de forma amigável o nome do documento onde a informação aparece (ex.: '05/04/2022 - Deferido o pedido').\n\n"
 
         "### Exemplos de interação\n"
         "Usuário: Quais são as partes envolvidas na execução de título "
@@ -111,3 +112,17 @@ def cached_completion(prompt: str) -> str:
         _RESP_CACHE[prompt] = answer
         save_caches()
     return answer or ""
+
+
+def humanize_doc_id(doc_id: str) -> str:
+    """Return a human friendly name for a given chunk/document id."""
+    base = doc_id.split("__")[0]
+    base = os.path.basename(base)
+    name = os.path.splitext(base)[0]
+    m = re.match(r"(\d{2})(\d{2})(\d{4})-\d{6}-(.+)", name)
+    if m:
+        day, month, year, slug = m.groups()
+        slug = slug.replace("-", " ").replace("_", " ")
+        slug = slug.capitalize()
+        return f"{day}/{month}/{year} - {slug}"
+    return name


### PR DESCRIPTION
## Summary
- adiciona função `humanize_doc_id` em `utils.py` para gerar nomes amigáveis
- ajusta instrução do sistema para citar documentos com nomes legíveis
- usa `humanize_doc_id` em `query.py` para mostrar nomes amigáveis no prompt

## Testing
- `python -m py_compile utils.py query.py memory.py ingest.py`

------
https://chatgpt.com/codex/tasks/task_e_684c6e01f5348326adfb95ba9784ec8c