### PR TITLE
Add Ollama support for local LLM use

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,14 @@ Durante a ingestão, os embeddings são persistidos em lote somente ao final do 
 
 Se esses arquivos ficarem corrompidos (por exemplo, erros de JSON), apague-os para que sejam recriados automaticamente.
 
+## Usando modelos locais com Ollama
+
+Caso tenha um modelo rodando via [Ollama](https://ollama.com) (por exemplo `llama3:8b`), defina a variável de ambiente `OLLAMA_MODEL` antes de executar o chat. Assim as respostas serão geradas pelo servidor local em vez da API da OpenAI.
+
+```bash
+export OLLAMA_MODEL="llama3:8b"
+python query.py
+```
+
+Você pode configurar o endpoint com `OLLAMA_URL` caso não seja `http://localhost:11434`.
+

--- a/query.py
+++ b/query.py
@@ -8,13 +8,11 @@ import numpy as np
 import gradio as gr
 from dotenv import load_dotenv
 
-from openai import OpenAI
 from memory import EphemeralMemory
 from utils import get_embedding, cached_completion, humanize_doc_id
 
 # Carrega configuração e modelos
 load_dotenv()  # garante OPENAI_API_KEY
-client = OpenAI()
 session_id = os.environ.get("SESSION_ID")
 memory = EphemeralMemory(session_id=session_id)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gradio
 python-dotenv
 langchain
 sentence-transformers
+requests


### PR DESCRIPTION
## Summary
- allow running the app with a local model served by Ollama
- use cached_completion for summarization
- mention Ollama usage in README
- install `requests`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68504eb3543883269305fa1f9a20b2a5