### PR TITLE
Fix default Ollama API base URL

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,11 @@ from openai import OpenAI
 
 # Configuration for optional Ollama usage
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL")
-OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/v1")
+# Base URL for an optional Ollama server. The official API endpoints live
+# directly under the server root, e.g. `http://localhost:11434/api/...`.
+# The previous default incorrectly included a `/v1` prefix which caused
+# requests to fail with a 404 error when using Ollama locally.
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
 
 try:
     from sentence_transformers import SentenceTransformer  # type: ignore


### PR DESCRIPTION
## Summary
- fix the OLLAMA_URL default path so local Ollama servers work out of the box

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851629883288326ba850a2f91c5109a